### PR TITLE
Add `render` def

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,10 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+/collision_meshes
+rlviser*
+assets.path
+/assets
+umodel
+settings.txt

--- a/example_rlviser.py
+++ b/example_rlviser.py
@@ -1,0 +1,30 @@
+import time
+
+import rlgym_sim
+
+TPS = 15
+
+env = rlgym_sim.make(spawn_opponents=True)
+
+while True:
+    obs = env.reset()
+
+    done = False
+    steps = 0
+    ep_reward = 0
+    t0 = time.time()
+    starttime = time.time()
+    while not done:
+        actions_1 = env.action_space.sample()
+        actions_2 = env.action_space.sample()
+        actions = [actions_1, actions_2]
+        new_obs, reward, done, state = env.step(actions)
+        env.render()
+        ep_reward += reward[0]
+        steps += 1
+
+        # Sleep to keep the game in real time
+        time.sleep(max(0, starttime + steps / TPS - time.time()))
+
+    length = time.time() - t0
+    print("Step time: {:1.5f} | Episode time: {:.2f} | Episode Reward: {:.2f}".format(length / steps, length, ep_reward))

--- a/rlgym_sim/gym.py
+++ b/rlgym_sim/gym.py
@@ -7,6 +7,11 @@ from rlgym_sim.simulator import RocketSimGame
 import RocketSim as rsim
 from rlgym_sim.utils import common_values
 
+try:
+    import rlviser_py as rlviser
+    rlviser.set_boost_pad_locations(common_values.BOOST_LOCATIONS)
+except ImportError:
+    rlviser = None
 
 class Gym(Env):
     def __init__(self, match, copy_gamestate_every_step, dodge_deadzone,
@@ -73,9 +78,19 @@ class Gym(Env):
         }
 
         return obs, reward, done, info
+    
+    def render(self):
+        if rlviser is None:
+            raise ImportError("rlviser_py not installed. Please install rlviser_py to use render()")
+
+        if self._prev_state is None:
+            return
+
+        rlviser.render_rlgym(self._prev_state)
 
     def close(self):
-        pass
+        if rlviser is not None:
+            rlviser.quit()
 
     def update_settings(self, gravity=None, boost_consumption=None, tick_skip=None):
         """


### PR DESCRIPTION
Uses [`rlviser-py`](https://github.com/VirxEC/rlviser-py) on pypi and [RLViser](https://github.com/VirxEC/rlviser) (has precompiled versions) to enable the `env.render()` so you can watch your ML bot play as it trains.

A basic example of real-time rendering (includes 8 tick skip, so it might look choppy in-game) is included with `example_rlviser.py`.

`rlgym_sim` is still usable without `rlviser-py` installed, and will only throw an error if you try to call `render` specifically without the package being installed.