### PR TITLE
Add subtick RLViser updates

### DIFF
--- a/example_render.py
+++ b/example_render.py
@@ -2,9 +2,7 @@ import time
 
 import rlgym_sim
 
-# Rocket League runs at 120 ticks per second
-# 1 / 240 will make the game run at 2x speed
-DT = 1 / 120
+TPS = 15
 
 env = rlgym_sim.make(spawn_opponents=True)
 
@@ -20,9 +18,13 @@ while True:
         actions_1 = env.action_space.sample()
         actions_2 = env.action_space.sample()
         actions = [actions_1, actions_2]
-        new_obs, reward, done, state = env.step(actions, dt=DT)
+        new_obs, reward, done, state = env.step(actions)
+        env.render()
         ep_reward += reward[0]
         steps += 1
+
+        # Sleep to keep the game in real time
+        time.sleep(max(0, starttime + steps / TPS - time.time()))
 
     length = time.time() - t0
     print("Step time: {:1.5f} | Episode time: {:.2f} | Episode Reward: {:.2f}".format(length / steps, length, ep_reward))

--- a/rlgym_sim/gym.py
+++ b/rlgym_sim/gym.py
@@ -1,10 +1,12 @@
 """
     The Rocket League gym environment.
 """
-from typing import List, Union, Tuple, Dict, Any
-from gym import Env
-from rlgym_sim.simulator import RocketSimGame
+from typing import Any, Dict, List, Tuple, Union
+
 import RocketSim as rsim
+from gym import Env
+
+from rlgym_sim.simulator import RocketSimGame
 from rlgym_sim.utils import common_values
 
 try:
@@ -52,7 +54,7 @@ class Gym(Env):
             return obs, info
         return obs
 
-    def step(self, actions: Any) -> Tuple[List, List, bool, Dict]:
+    def step(self, actions: Any, dt=None) -> Tuple[List, List, bool, Dict]:
         """
         The step function will send the list of provided actions to the game, then advance the game forward by `tick_skip`
         physics ticks using that action. The game is then paused, and the current state is sent back to rlgym_sim This is
@@ -65,7 +67,7 @@ class Gym(Env):
 
         actions = self._match.format_actions(self._match.parse_actions(actions, self._prev_state))
 
-        state = self._game.step(actions)
+        state = self._game.step(actions, dt, self.render)
 
         obs = self._match.build_observations(state)
         done = self._match.is_done(state)
@@ -79,14 +81,16 @@ class Gym(Env):
 
         return obs, reward, done, info
     
-    def render(self):
+    def render(self, state=None):
         if rlviser is None:
             raise ImportError("rlviser_py not installed. Please install rlviser_py to use render()")
 
-        if self._prev_state is None:
-            return
+        if state is None:
+            if self._prev_state is None:
+                return
+            state = self._prev_state
 
-        rlviser.render_rlgym(self._prev_state)
+        rlviser.render_rlgym(state)
 
     def close(self):
         if rlviser is not None:


### PR DESCRIPTION
Per-tick updates are still easy: call `env.render()` as fast as you want
Or, if you don't care about going fast, passing `dt` for the `env.step` will enable sub-tick updates and run the game slower
 - `dt` will probably be `1 / 120` to run in real-time
 - Works by:
   - `sleep`-ing the needed amount of time to match `dt`
   - `step(1)`
   - `_build_gamestate`
   - `render`
   - Repeat `tick_skip` times
 - If `dt` stays defined as `None`, then `step(tick_skip-1)` is still called like normal to prevent a loss of performance when you actually want it

Sub-tick RLViser updates actually provide smooth gameplay as the total `120` packets and not `120 / tick_skip`